### PR TITLE
Fix stall from querying weather too frequently

### DIFF
--- a/include/weather.class.php
+++ b/include/weather.class.php
@@ -1,8 +1,8 @@
 <?php
 
 define('WEATHER_FORECAST_URL',		'http://forecast.weather.gov/MapClick.php?');
-define('WEATHER_USERAGENT_STRING',	'CambridgeCollegeRapidSignage/0.2.0 (Web Application, https://github.com/genericAnomaly/rapidsign)');
-define('WEATHER_CACHE_MINUTES',		'30');
+define('WEATHER_USERAGENT_STRING',	'CambridgeCollegeRapidSignage/0.2.1 (Web Application, https://github.com/genericAnomaly/rapidsign)');
+define('WEATHER_CACHE_MINUTES',		'60');
 
 //http://forecast.weather.gov/MapClick.php?lat=42.3798&lon=-71.1284&FcstType=json
 


### PR DESCRIPTION
Changes weather cache to stay fresh for 60 minutes instead of just 30;
the NOAA servers were getting fed up and returning empty results, and
there needs to be better fault tolerance for that, but this was the
short-term fix.